### PR TITLE
patch member.get_role to work for default roles

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -966,7 +966,7 @@ class Member(discord.abc.Messageable, _UserTag):
         Optional[:class:`Role`]
             The role or ``None`` if not found in the member's roles.
         """
-        return self.guild.get_role(role_id) if self._roles.has(role_id) else None
+        return self.guild.get_role(role_id) if self._roles.has(role_id) or self.guild.id == role_id else None
 
     def has_role(self, role: Snowflake, /) -> bool:
         """Returns a boolean indicating if the member has the given role.
@@ -983,4 +983,4 @@ class Member(discord.abc.Messageable, _UserTag):
         :class:`bool`
             Whether or not this member has the given role.
         """
-        return self._roles.has(role.id)
+        return self._roles.has(role.id) or self.guild.id == role.id

--- a/discord/member.py
+++ b/discord/member.py
@@ -966,7 +966,7 @@ class Member(discord.abc.Messageable, _UserTag):
         Optional[:class:`Role`]
             The role or ``None`` if not found in the member's roles.
         """
-        return self.guild.get_role(role_id) if self._roles.has(role_id) or self.guild.id == role_id else None
+        return self.guild.get_role(role_id) if self.guild.id == role_id or self._roles.has(role_id) else None
 
     def has_role(self, role: Snowflake, /) -> bool:
         """Returns a boolean indicating if the member has the given role.
@@ -983,4 +983,4 @@ class Member(discord.abc.Messageable, _UserTag):
         :class:`bool`
             Whether or not this member has the given role.
         """
-        return self._roles.has(role.id) or self.guild.id == role.id
+        return self.guild.id == role.id or self._roles.has(role.id)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes get_role and has_role to account for the guilds default role
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
