### PR TITLE
add `Range[M, N]` helper annotation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4410,6 +4410,11 @@ ApplicationCommandTree
 .. autoclass:: discord.application_commands.ApplicationCommandTree
     :members:
 
+Range
+~~~~~
+
+.. autoclass:: discord.application_commands.Range
+
 SlashCommand
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds a `Range[M, N]` helper to specify min_value and max_value kwargs in a more concise manner.

ex: `x: int = option(min_value=2, max_value=5)` becomes `x: Range[2, 5]`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
