### PR TITLE
fix response.edit_message not working for modal submit

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -1141,7 +1141,7 @@ class InteractionResponse:
         msg = parent.message
         state = parent._state
         message_id = msg.id if msg else None
-        if parent.type is not InteractionType.component:
+        if parent.type not in (InteractionType.component, InteractionType.modal_submit):
             return
 
         payload = {}


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
`InteractionResponse.edit_message` was only valid for component type interactions.

Added modal submit to valid types.
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
